### PR TITLE
fix: removed slug field ref from courses page

### DIFF
--- a/community/www/courses/index.py
+++ b/community/www/courses/index.py
@@ -3,7 +3,6 @@ import frappe
 def get_context(context):
     context.no_cache = 1
     context.courses = get_courses()
-    print(context)
 
 def get_courses():
     courses = frappe.get_all(

--- a/community/www/courses/index.py
+++ b/community/www/courses/index.py
@@ -3,10 +3,11 @@ import frappe
 def get_context(context):
     context.no_cache = 1
     context.courses = get_courses()
+    print(context)
 
 def get_courses():
     courses = frappe.get_all(
         "LMS Course",
-        fields=['name', 'slug', 'title', 'description']
+        fields=['name', 'title', 'description']
     )
     return courses


### PR DESCRIPTION
1. Slug field was being referenced on the courses page.
2. As we don't have a slug field anymore, the courses page was not appearing on new sites.