### PR TITLE
fix: ignore user permission for membership

### DIFF
--- a/community/lms/doctype/lms_batch_membership/lms_batch_membership.js
+++ b/community/lms/doctype/lms_batch_membership/lms_batch_membership.js
@@ -2,7 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('LMS Batch Membership', {
-	// refresh: function(frm) {
-
-	// }
+	onload: function(frm) {
+		frm.set_query('member', function(doc) {
+			return {
+				filters: {
+					"ignore_user_type": 1,
+				}
+			};
+		});
+	},
 });


### PR DESCRIPTION
1. LMS Batch Membership has a field member which is linked to the User doctype.
2. This link field was not considering Website Users.
3. Added a filter ignore_user_type to allow Website Users.