### PR TITLE
feat: actions to reindex lessons and exercises

### DIFF
--- a/community/lms/doctype/chapter/chapter.py
+++ b/community/lms/doctype/chapter/chapter.py
@@ -10,6 +10,6 @@ class Chapter(Document):
     def get_lessons(self):
         rows = frappe.db.get_all("Lesson",
             filters={"chapter": self.name},
-            fields='*',
+            fields='name',
             order_by="index_")
-        return [frappe.get_doc(dict(row, doctype='Lesson')) for row in rows]
+        return [frappe.get_doc('Lesson', row['name']) for row in rows]

--- a/community/lms/doctype/exercise/exercise.json
+++ b/community/lms/doctype/exercise/exercise.json
@@ -15,7 +15,9 @@
   "hints",
   "tests",
   "image",
-  "lesson"
+  "lesson",
+  "index_",
+  "index_label"
  ],
  "fields": [
   {
@@ -27,6 +29,7 @@
   {
    "fieldname": "course",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Course",
    "options": "LMS Course"
   },
@@ -73,13 +76,27 @@
   {
    "fieldname": "lesson",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Lesson",
    "options": "Lesson"
+  },
+  {
+   "fieldname": "index_",
+   "fieldtype": "Int",
+   "label": "Index",
+   "read_only": 1
+  },
+  {
+   "fieldname": "index_label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Index Label",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-20 13:23:12.340928",
+ "modified": "2021-06-01 05:22:15.656013",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Exercise",
@@ -99,8 +116,8 @@
   }
  ],
  "search_fields": "title",
- "sort_field": "modified",
- "sort_order": "DESC",
+ "sort_field": "index_label",
+ "sort_order": "ASC",
  "title_field": "title",
  "track_changes": 1
 }

--- a/community/lms/doctype/exercise/exercise.py
+++ b/community/lms/doctype/exercise/exercise.py
@@ -25,7 +25,6 @@ class Exercise(Document):
             order_by="creation desc",
             page_length=1)
 
-        print("get_user_submission", result)
         if result:
             return result[0]
 

--- a/community/lms/doctype/lesson/lesson.json
+++ b/community/lms/doctype/lesson/lesson.json
@@ -10,6 +10,7 @@
   "lesson_type",
   "title",
   "index_",
+  "index_label",
   "body",
   "sections"
  ],
@@ -51,11 +52,18 @@
    "fieldtype": "Table",
    "label": "Sections",
    "options": "LMS Section"
+  },
+  {
+   "fieldname": "index_label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Index Label",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-13 20:03:51.510605",
+ "modified": "2021-06-01 05:30:48.127494",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "Lesson",

--- a/community/lms/doctype/lesson/lesson.py
+++ b/community/lms/doctype/lesson/lesson.py
@@ -20,6 +20,9 @@ class Lesson(Document):
     def get_sections(self):
         return sorted(self.get('sections'), key=lambda s: s.index)
 
+    def get_exercises(self):
+        return [frappe.get_doc("Exercise", s.id) for s in self.get("sections") if s.type=="exercise"]
+
     def make_lms_section(self, index, section):
             s = frappe.new_doc('LMS Section', parent_doc=self, parentfield='sections')
             s.type = section.type

--- a/community/lms/doctype/lesson/lesson.py
+++ b/community/lms/doctype/lesson/lesson.py
@@ -16,6 +16,21 @@ class Lesson(Document):
                 e = s.get_exercise()
                 e.lesson = self.name
                 e.save()
+        self.update_orphan_exercises()
+
+    def update_orphan_exercises(self):
+        """Updates the exercises that were previously part of this lesson,
+        but not any more.
+        """
+        linked_exercises = {row['name'] for row in frappe.get_all('Exercise', {"lesson": self.name})}
+        active_exercises = {s.id for s in self.get("sections") if s.type=="exercise"}
+        orphan_exercises = linked_exercises - active_exercises
+        for name in orphan_exercises:
+            ex = frappe.get_doc("Exercise", name)
+            ex.lesson = None
+            ex.index_ = 0
+            ex.index_label = ""
+            ex.save()
 
     def get_sections(self):
         return sorted(self.get('sections'), key=lambda s: s.index)

--- a/community/lms/doctype/lms_course/lms_course.json
+++ b/community/lms/doctype/lms_course/lms_course.json
@@ -1,5 +1,18 @@
 {
- "actions": [],
+ "actions": [
+  {
+   "action": "community.lms.doctype.lms_course.lms_course.reindex_lessons",
+   "action_type": "Server Action",
+   "group": "Reindex",
+   "label": "Reindex Lessons"
+  },
+  {
+   "action": "community.lms.doctype.lms_course.lms_course.reindex_exercises",
+   "action_type": "Server Action",
+   "group": "Reindex",
+   "label": "Reindex Exercises"
+  }
+ ],
  "allow_guest_to_view": 1,
  "allow_rename": 1,
  "creation": "2021-03-01 16:49:33.622422",
@@ -86,7 +99,7 @@
    "link_fieldname": "course"
   }
  ],
- "modified": "2021-05-23 18:14:32.602647",
+ "modified": "2021-06-01 04:36:45.696776",
  "modified_by": "Administrator",
  "module": "LMS",
  "name": "LMS Course",

--- a/community/lms/widgets/Exercise.html
+++ b/community/lms/widgets/Exercise.html
@@ -1,7 +1,7 @@
 {% from "www/macros/livecode.html" import LiveCodeEditorJS, LiveCodeEditor with context %}
 
 <div class="exercise">
-  <h2>{{ exercise.title }}</h2>
+  <h2>Exercise {{exercise.index_label}}: {{ exercise.title }}</h2>
   <div class="exercise-description">{{frappe.utils.md_to_html(exercise.description)}}</div>
 
   {% if exercise.image %}

--- a/community/www/batch/progress.html
+++ b/community/www/batch/progress.html
@@ -29,7 +29,7 @@
     <h1>Batch Progress</h1>
     {% for exercise in report.exercises %}
     <div class="exercise-submissions">
-      <h2>{{exercise.title}}</h2>
+      <h2>Exercise {{exercise.index_label}}: {{exercise.title}}</h2>
       {% for s in report.get_submissions_of_exercise(exercise.name) %}
       <div class="submission">
         <h4><a href="/{{s.owner.username}}">{{s.owner.full_name}}</a></h4>

--- a/community/www/batch/progress.py
+++ b/community/www/batch/progress.py
@@ -25,7 +25,7 @@ class BatchReport:
             self.submissions_by_exercise[s.exercise].append(s)
 
     def get_exercises(self, course_name):
-        return frappe.get_all("Exercise", {"course": course_name}, ["name", "title", "index_label"], order_by="index_label")
+        return frappe.get_all("Exercise", {"course": course_name, "lesson": ["!=", ""]}, ["name", "title", "index_label"], order_by="index_label")
 
     def get_submissions_of_exercise(self, exercise_name):
         return self.submissions_by_exercise[exercise_name]

--- a/community/www/batch/progress.py
+++ b/community/www/batch/progress.py
@@ -25,7 +25,7 @@ class BatchReport:
             self.submissions_by_exercise[s.exercise].append(s)
 
     def get_exercises(self, course_name):
-        return frappe.get_all("Exercise", {"course": course_name}, ["name", "title"])
+        return frappe.get_all("Exercise", {"course": course_name}, ["name", "title", "index_label"], order_by="index_label")
 
     def get_submissions_of_exercise(self, exercise_name):
         return self.submissions_by_exercise[exercise_name]


### PR DESCRIPTION
 Some lessons gets deleted and some new ones get added as part of course creation and it may happen then some of the lesson index may become inconsistent.  Also, we would like to maintain an index for the  exercises. To support both of these, added actions to reindex lessons  and exercises to the course doctype.

Changes:
- add `index_label` field to lesson and exercise and that would have values like `"1.2"`, `"2.3"`  etc.
- add `index_` field to the exercise (that is already present in lesson)
- add actions to "Reindex Lessons"  and "Reindex Exercises" to desk to update index and index_label fields
- remove index and index_label from exercises that were not part of any lesson
- show exercise like "Exercise 1.2: Draw a circle", using the index_label 
- ignore orphan exercises when showing the progress