### PR TITLE
fix: issue with numbering the exercises

### DIFF
--- a/community/lms/doctype/lesson/lesson.py
+++ b/community/lms/doctype/lesson/lesson.py
@@ -11,11 +11,15 @@ class Lesson(Document):
     def before_save(self):
         sections = SectionParser().parse(self.body or "")
         self.sections = [self.make_lms_section(i, s) for i, s in enumerate(sections)]
+
+        index = 1
         for s in self.sections:
             if s.type == "exercise":
                 e = s.get_exercise()
                 e.lesson = self.name
+                e.index_ = index
                 e.save()
+                index += 1
         self.update_orphan_exercises()
 
     def update_orphan_exercises(self):


### PR DESCRIPTION
The exercises being listed in unpredicted order instead of the order
they were listed in the lesson. The was because the `index_` of the
exercise was never updated. Fixed this by updating the `index_` whenever
a lesson edited. However, the user still need to run reindex exercises
on the course correct the ordering, which wasn't possible earlier.