### PR TITLE
fix: remove references to old styles in the hooks

### DIFF
--- a/community/hooks.py
+++ b/community/hooks.py
@@ -19,7 +19,6 @@ app_license = "AGPL"
 # app_include_js = "/assets/community/js/community.js"
 
 # include js, css files in header of web template
-web_include_css = "community.bundle.css"
 # web_include_css = "/assets/community/css/community.css"
 # web_include_js = "/assets/community/js/community.js"
 


### PR DESCRIPTION
Old styles were removed in #157, but a reference to it was hanging
around in the hooks.