### PR TITLE
fix: discussions markdown support

### DIFF
--- a/community/templates/discussions/reply_card.html
+++ b/community/templates/discussions/reply_card.html
@@ -9,5 +9,5 @@
     <div class="ml-2 frappe-timestamp" data-timestamp="{{ reply.creation }}"> just now </div>
   </div>
   <div class="card-divider mt-3"></div>
-  <div class="reply-text">{{ reply.reply }}</div>
+  <div class="markdown-source reply-text">{{ frappe.utils.md_to_html(reply.reply) }}</div>
 </div>


### PR DESCRIPTION
### Markdown support for replies

![Screenshot 2021-09-14 at 4 23 54 PM](https://user-images.githubusercontent.com/31363128/133245195-69d196c8-718f-4adf-8291-beafa845cbb3.png)
