### PR TITLE
fix: preview message

### DIFF
--- a/community/lms/widgets/ChapterTeaser.html
+++ b/community/lms/widgets/ChapterTeaser.html
@@ -35,7 +35,7 @@
 
         {% elif is_instructor and not lesson.include_in_preview %}
         <a class="lesson-links"
-        title="This lesson is not available for preview but as an instructor you can access it."
+        title="This lesson is not available for preview. As you are the Instructor of the course only you can see it."
         href="{{ course.get_learn_url(lesson.number) }}{{course.query_parameter}}"
         data-course="{{ course.name }}">
         {{ lesson.title }}

--- a/community/www/batch/learn.html
+++ b/community/www/batch/learn.html
@@ -48,7 +48,7 @@
 
   {% if membership or lesson.include_in_preview or is_instructor %}
   <div class="common-card-style lesson-content-card markdown-source">
-    {% if is_instructor %}
+    {% if is_instructor and not lesson.include_in_preview %}
     <small class="alert alert-secondary alert-dismissible">
       This lesson is not available for preview. As you are the Instructor of the course only you can see it.
       <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>


### PR DESCRIPTION
1. The preview message for instructors was appearing even for lessons that are available for preview. Fixed that.
2. Changed the tooltip message for the course outline to match with the message that appears above the lesson.

![Screenshot 2021-09-27 at 12 52 45 PM](https://user-images.githubusercontent.com/31363128/134862949-8852b089-770c-4b25-96a3-8c87c3acd395.png)

