### PR TITLE
fix: avoid creating duplicate entries of LMS Course Interest

### DIFF
--- a/community/lms/doctype/lms_course_interest/lms_course_interest.py
+++ b/community/lms/doctype/lms_course_interest/lms_course_interest.py
@@ -9,9 +9,11 @@ class LMSCourseInterest(Document):
 
 @frappe.whitelist()
 def capture_interest(course):
-    frappe.get_doc({
+    data = {
         "doctype": "LMS Course Interest",
         "course": course,
         "user": frappe.session.user
-    }).save(ignore_permissions=True)
+    }
+    if not frappe.db.exists(data):
+        frappe.get_doc(data).save(ignore_permissions=True)
     return "OK"


### PR DESCRIPTION
It is possible to create duplicate entries of course interest if the course page is opened it in two tabs and the user clicks "notify when available" button on each of this. 

This PR takes care of the issue by checking if an entry already exists before creating a new one.