### PR TITLE
feat: live and upcoming course headers

### DIFF
--- a/community/www/courses/index.html
+++ b/community/www/courses/index.html
@@ -9,14 +9,29 @@
 {% block content %}
 <div class="common-page-style">
   <div class="container">
+
+    {% if live_courses | length %}
     <div class="courses-header">
-      {{ 'All Courses' }}
+      {{ _('Live Courses') }}
     </div>
     <div class="cards-parent">
-      {% for course in courses %}
+      {% for course in live_courses %}
       {{ widgets.CourseCard(course=course, read_only=False) }}
       {% endfor %}
     </div>
+    {% endif %}
+
+    {% if upcoming_courses | length %}
+    <div class="courses-header mt-12">
+      {{ _('Upcoming Courses') }}
+    </div>
+    <div class="cards-parent">
+      {% for course in upcoming_courses %}
+      {{ widgets.CourseCard(course=course, read_only=False) }}
+      {% endfor %}
+    </div>
+    {% endif %}
+
   </div>
 </div>
 {% endblock %}

--- a/community/www/courses/index.py
+++ b/community/www/courses/index.py
@@ -2,7 +2,7 @@ import frappe
 
 def get_context(context):
     context.no_cache = 1
-    context.courses = get_courses()
+    context.live_courses, context.upcoming_courses = get_courses()
     context.metatags = {
         "title": "All Courses",
         "image": frappe.db.get_single_value("Website Settings", "banner_image"),
@@ -11,8 +11,14 @@ def get_context(context):
     }
 
 def get_courses():
-    course_names = frappe.get_all("LMS Course", filters={"is_published": True}, order_by="upcoming", pluck="name")
-    courses = []
+    course_names = frappe.get_all("LMS Course",
+                                filters={"is_published": True},
+                                fields=["name", "upcoming"])
+
+    live_courses, upcoming_courses = [], []
     for course in course_names:
-        courses.append(frappe.get_doc("LMS Course", course))
-    return courses
+        if course.upcoming:
+            upcoming_courses.append(frappe.get_doc("LMS Course", course.name))
+        else:
+            live_courses.append(frappe.get_doc("LMS Course", course.name))
+    return live_courses, upcoming_courses


### PR DESCRIPTION
1. Separating Live and Upcoming Courses on the All Courses Page.