### PR TITLE
fix: relaod doctypes in patch

### DIFF
--- a/community/patches.txt
+++ b/community/patches.txt
@@ -12,4 +12,4 @@ community.patches.v0_0.course_instructor_update
 execute:frappe.delete_doc("DocType", "Discussion Message")
 execute:frappe.delete_doc("DocType", "Discussion Thread")
 community.patches.v0_0.rename_chapters_and_lessons_doctype
-community.patches.v0_0.rename_chapter_and_lesson_doctype #29-09-2021
+community.patches.v0_0.rename_chapter_and_lesson_doctype #30-09-2021

--- a/community/patches/v0_0/rename_chapter_and_lesson_doctype.py
+++ b/community/patches/v0_0/rename_chapter_and_lesson_doctype.py
@@ -3,6 +3,14 @@ import frappe
 def execute():
     frappe.reload_doc("lms", "doctype", "course_chapter")
     frappe.reload_doc("lms", "doctype", "course_lesson")
+    frappe.reload_doc("lms", "doctype", "chapter_reference")
+    frappe.reload_doc("lms", "doctype", "lesson_reference")
+    frappe.reload_doc("lms", "doctype", "exercise")
+    frappe.reload_doc("lms", "doctype", "exercise_submission")
+    frappe.reload_doc("lms", "doctype", "lms_batch_membership")
+    frappe.reload_doc("lms", "doctype", "lms_course")
+    frappe.reload_doc("lms", "doctype", "lms_course_progress")
+    frappe.reload_doc("lms", "doctype", "lms_quiz")
 
     if not frappe.db.count("Course Chapter"):
         move_chapters()


### PR DESCRIPTION
1. Reload all affected doctypes in patch that handles renaming of Chapter and Lesson doctype