### PR TITLE
fix: api call for progress save

### DIFF
--- a/community/www/batch/learn.js
+++ b/community/www/batch/learn.js
@@ -68,7 +68,7 @@ var mark_active_question = (e = undefined) => {
 var mark_progress = (e) => {
   var status = $(e.currentTarget).attr("data-progress");
   frappe.call({
-    method: "community.lms.doctype.lesson.lesson.save_progress",
+    method: "community.lms.doctype.course_lesson.course_lesson.save_progress",
     args: {
       lesson: $(".title").attr("data-lesson"),
       course: $(".title").attr("data-course"),


### PR DESCRIPTION
**Issue:**

1. API call to save lesson progress was pointing to old doctype location.

**Fix:**

1. Changed the API call to point to the new doctype location